### PR TITLE
Guard every mode alternative, not just the first

### DIFF
--- a/tools/decoder/Program.cs
+++ b/tools/decoder/Program.cs
@@ -2764,7 +2764,7 @@ unsafe
     //   The record hangs off part+0x18, which is heap, so this reads it through a sounding voice
     //   rather than off any static address.
     //   args: dll drumnrpn <note> [value] [gs|xg] [prog]
-    if (args.Length > 1 && args[1] == "drumnrpn" || args[1] == "svfslew")
+    if (args.Length > 1 && (args[1] == "drumnrpn" || args[1] == "svfslew"))
     {
         int ntn=int.Parse(args[2]);
         int valn=args.Length>3?int.Parse(args[3]):0x50;
@@ -2820,7 +2820,7 @@ unsafe
     //   setup records live behind a pointer the module allocates, so a static dump cannot see them.
     //   args: dll xgdrumfilt <note> <param> <value> [prog]
     //   param is the XG Drum Setup parameter: 0b filter cutoff, 0c filter resonance, 02 level.
-    if (args.Length > 1 && args[1] == "xgdrumfilt" || args[1] == "drumnrpn" || args[1] == "svfslew")
+    if (args.Length > 1 && (args[1] == "xgdrumfilt" || args[1] == "drumnrpn" || args[1] == "svfslew"))
     {
         int ntx=int.Parse(args[2]);
         int prmx=Convert.ToInt32(args[3],16);
@@ -3201,7 +3201,7 @@ unsafe
     // drumnote mode: strike ONE drum note on ch10 and render it alone, for per-instrument A/B.
     //   (a lone hit cannot be compared against drumsong's opening -- a crash and hat fire with it)
     //   args: dll drumnote <kit> <note> <vel> <sec> <out.wav>
-    if (args.Length > 1 && args[1] == "drumnote" || args[1] == "panscan")
+    if (args.Length > 1 && (args[1] == "drumnote" || args[1] == "panscan"))
     {
         // (arg 7, if present, is a CSV path: also dump the full voice struct per control tick)
         int SR6=32000; int kit6=int.Parse(args[2]); int nt6=int.Parse(args[3]);


### PR DESCRIPTION
`scdec <dll>` with no mode always threw `IndexOutOfRangeException`, so the smoke test the harness is
meant to start with could not pass on any build.

`&&` binds tighter than `||`, so

```csharp
if (args.Length > 1 && args[1] == "drumnrpn" || args[1] == "svfslew")
```

parses as `(args.Length > 1 && args[1] == "drumnrpn") || (args[1] == "svfslew")`, and the length
guard covers only the first alternative. With just the DLL passed, the first clause short-circuits
false and the second reads `args[1]` out of an array of one.

## Three sites, not one

2767, 2823 and 3204. Two were found first and the third only surfaced once those were fixed, because
each crash hides the ones after it — so this was three bugs wearing a single symptom.

## Blast radius

Nil for captures: every real mode passes `args[1]`, so the expression was only ever reached unsafely
on the bare-DLL invocation. What it cost was diagnosis. `module base = ...` prints before the throw,
so the DLL had demonstrably loaded and resolved, and a crash immediately after that invites the
conclusion that the module or the build is at fault rather than the argument parsing.

## Verification

Under wine against the pinned DLL. The bare invocation now completes its decode —
`peak=8230 rms=2937 zerocross%=9.5`, a coherent waveform rather than noise, which is what that
smoke test exists to show. `smf`, `revdump` and `chodump` produce output byte-identical to a build
made before this change, so no mode's behaviour moved.